### PR TITLE
Fixes #8, changed regular expression for logs to not cut multi-line logs

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -48,7 +48,7 @@ const (
 	//timestampRegexp = `(?P<YYYY>\d{4})-(?P<MM>\d{2})-(?P<DD>\d{2})[( |T)](?P<HH>\d{2}):(?P<mm>\d{2}):(?P<ss>\d{2})[.]?(?P<s>\d+)?`
 
 	timestampRegexp = `(?P<timestamp>(\d{4})-(\d{2})-(\d{2})[( |T)](\d{2}):(\d{2}):(\d{2})[.]?(\d+)?)`
-	logRegexp       = timestampRegexp + `[ ](?P<pid>\d+)[ ](?P<severity_label>\S+)[ ](?P<python_module>\S+)[ ](?P<payload>.*)`
+	logRegexp       = timestampRegexp + `[ ](?P<pid>\d+)[ ](?P<severity_label>\S+)[ ](?P<python_module>\S+)[ ](?P<payload>(\n|.)*)`
 
 	// ***	2) PATTERN FOR REQUEST CONTEXT   ***
 	// 	Openstack payload might include a request context which can tak multiple forms:

--- a/processor/processor_medium_test.go
+++ b/processor/processor_medium_test.go
@@ -261,7 +261,8 @@ var mockNovaLogs = []*TestCase{
 				"<capabilities>\n<host><uuid>03aa02fc-0414-0590-8906-ca0700080009</uuid>\n</host>\n</capabilities>\n",
 		},
 		output: testOutput{
-			data: "[req-407244e7-4ef1-4180-b139-372e705eda9e - - - - -] Libvirt host capabilities ",
+			data: "[req-407244e7-4ef1-4180-b139-372e705eda9e - - - - -] Libvirt host capabilities \n" +
+				"<capabilities>\n<host><uuid>03aa02fc-0414-0590-8906-ca0700080009</uuid>\n</host>\n</capabilities>\n",
 			tags: map[string]string{
 				"severity_label": "INFO",
 				"severity":       "6",
@@ -335,6 +336,28 @@ var mockHeatLogs = []*TestCase{
 				"http_response_time":     "0.000323",
 				"http_client_ip_address": "10.108.8.212",
 				"http_server_ip_address": "10.0.0.1",
+			},
+		},
+	},
+	&TestCase{
+		input: testInput{
+			logFileName: "heat-api-cfn.log",
+			logData: "2017-01-04 15:25:29.445 6 INFO eventlet.wsgi.server [-] Traceback (most recent call last):\n" +
+				" File \"/var/lib/kolla/venv/local/lib/python2.7/site-packages/eventlet/wsgi.py\", line 481, in handle_one_response\n" +
+				"   result = self.application(self.environ, start_response)\n" +
+				"UnicodeDecodeError: 'utf8' codec can't decode bytes in position 12-13: invalid continuation byte\n\n",
+		},
+		output: testOutput{
+			data: "[-] Traceback (most recent call last):\n" +
+				" File \"/var/lib/kolla/venv/local/lib/python2.7/site-packages/eventlet/wsgi.py\", line 481, in handle_one_response\n" +
+				"   result = self.application(self.environ, start_response)\n" +
+				"UnicodeDecodeError: 'utf8' codec can't decode bytes in position 12-13: invalid continuation byte\n\n",
+			tags: map[string]string{
+				"severity_label": "INFO",
+				"severity":       "6",
+				"pid":            "6",
+				"python_module":  "eventlet.wsgi.server",
+				"logger":         "openstack.heat",
 			},
 		},
 	},


### PR DESCRIPTION
Fixes #8

Summary of changes:
- Changed regular expression for logs to not cut multi-line logs

How to verify it:
- make tests for multi-line logs

Testing done:
- small, medium tests,
- manual tests

